### PR TITLE
Allow using any docker API options without requiring explicit support/aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ var stream = build(tag, [options])
   host: '/var/run/docker.sock', // host to docker
   cache: true, // whether or not to use docker fs cache (defaults to true)
   quiet: false, // be quiet - defaults to false,
-  registry: conf // add a registry config
+  registry: conf, // add a registry config
+  buildOptions: {} // An object of docker remote api options, `t` will always be overwritten by `tag`
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var build = function(tag, opts) {
   var dup = duplexify()
   var request = opts.request || docker(opts.host)
 
-  var qs = {}
+  var qs = opts.buildOptions || {}
   qs.t = tag
 
   if (opts.cache === false) qs.nocache = 'true'


### PR DESCRIPTION
This allows using the `rm` and `forcerm` options, along with any options that may be used in future.  I'm happy to use a different name, or even just use aliases (although with this approach there is no need to update to use new docker options)
