### PR TITLE
add --api-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ var stream = build(tag, [options])
   registry: conf, // add a registry config
   remove: true, // automatically removes intermediate contaners (defaults to true)
   forceremove: false, // always remove intermediate containers, even if the build fails (defaults to false)
-  version: 'v1.15' // docker api version (defaults to 'v1.15')
+  version: 'v1.22' // docker api version (defaults to 'v1.22')
 }
 ```
+
+**Note:** The `version` property corresponds to the [`Docker Remote API`](https://docs.docker.com/engine/reference/api/docker_remote_api/) version.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ var stream = build(tag, [options])
   quiet: false, // be quiet - defaults to false,
   registry: conf, // add a registry config
   remove: true, // automatically removes intermediate contaners (defaults to true)
-  forceremove: false // always remove intermediate containers, even if the build fails (defaults to false)
+  forceremove: false, // always remove intermediate containers, even if the build fails (defaults to false)
+  version: 'v1.15' // docker api version (defaults to 'v1.15')
 }
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,8 @@ var argv = minimist(process.argv, {
     host: 'H'
   },
   default: {
-    cache: true
+    cache: true,
+    'api-version': 'v1.15'
   }
 })
 
@@ -40,9 +41,10 @@ if (argv.help || !tag) {
   console.error(
     'Usage: docker-build [tag] [path?] [options]\n'+
     '\n'+
-    '  --host,    -H   [docker-host]\n'+
-    '  --quiet,   -q\n'+
-    '  --version, -v\n'+
+    '  --host,        -H   [docker-host]\n'+
+    '  --quiet,       -q\n'+
+    '  --version,     -v\n'+
+    '  --api-version       [api version (v1.15)]\n'+
     '  --no-cache\n'+
     '  --no-ignore\n'
   )
@@ -57,7 +59,8 @@ var onerror = function(err) {
 var opts = {
   host: argv.host,
   cache: argv.cache,
-  quiet: argv.quiet
+  quiet: argv.quiet,
+  version: argv['api-version']
 }
 
 var input = function() {

--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,7 @@ var argv = minimist(process.argv, {
   },
   default: {
     cache: true,
-    'api-version': 'v1.15'
+    'api-version': 'v1.22'
   }
 })
 
@@ -44,7 +44,7 @@ if (argv.help || !tag) {
     '  --host,        -H   [docker-host]\n'+
     '  --quiet,       -q\n'+
     '  --version,     -v\n'+
-    '  --api-version       [api version (v1.15)]\n'+
+    '  --api-version       [api version (v1.22)]\n'+
     '  --no-cache\n'+
     '  --no-ignore\n'
   )

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var build = function(tag, opts) {
 
   var post = request.post('/build', {
     qs: qs,
-    version: opts.version || 'v1.15',
+    version: opts.version || 'v1.22',
     headers: {
       'Content-Type': 'application/tar',
       'X-Registry-Config': opts.registry


### PR DESCRIPTION
Maybe we should consider upping it to `'v1.22'` as default since `'v1.15'` seems quite old?
